### PR TITLE
:bug: Switched from single Queue to N Queues (based on topic keys)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - export GO111MODULE=on && go mod download
 - docker pull rabbitmq:3.7.4
 - docker run -p 5672:5672 -e RABBITMQ_DEFAULT_USER="user" -e RABBITMQ_DEFAULT_PASS="pass" -d --restart always --name ci_rabbitmq rabbitmq:3.7.4
-- go get -u golang.org/x/lint/golint
+- go get golang.org/x/lint/golint
 
 script:
 - golint ./...

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Queue. Information on the Topology of the Queue can be found [here](#Topology)
 
 ### Topology
 
-1 Exchange & 1 Topic, which can be set using `RMQ_QUEUE` & `RMQ_EXCHANGE`.
+1 Exchange (set via `RMQ_EXCHANGE`) & N Topic (set per topic with naming schema `OpenFaaS_TOPIC`)
 
 **Exchange:**
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 var (
-	connector subscriber.Connector
-	mockClient *invokerMock
+	connector      subscriber.Connector
+	mockClient     *invokerMock
 	producerClient *Producer
 )
 
 type Invocation struct {
-	Topic string
-	Message *[]byte
+	Topic      string
+	Message    *[]byte
 	ReceivedNo uint
 }
 
@@ -37,9 +37,9 @@ type Producer struct {
 	counter uint
 
 	exchange string
-	topic string
+	topic    string
 
-	mutex           sync.Mutex
+	mutex sync.Mutex
 }
 
 func NewProducer(cfg *config.Controller) (*Producer, error) {
@@ -64,7 +64,7 @@ func (p *Producer) setup(cfg *config.Controller) error {
 		nil,
 	)
 
-	if err != nil{
+	if err != nil {
 		return err
 	}
 	p.exchange = cfg.ExchangeName
@@ -80,27 +80,27 @@ func (p *Producer) SendMessage(body *[]byte) error {
 	err := p.channel.Publish(
 		p.exchange,
 		p.topic,
-			false,
-			false,
-			amqp.Publishing{
-				DeliveryMode: amqp.Persistent,
-				ContentType: "text/plain",
-				Body:        *body,
-				Timestamp: time.Now(),
-			})
+		false,
+		false,
+		amqp.Publishing{
+			DeliveryMode: amqp.Persistent,
+			ContentType:  "text/plain",
+			Body:         *body,
+			Timestamp:    time.Now(),
+		})
 
 	return err
 }
 
 //---- Invoker Mock ----//
 type invokerMock struct {
-	invocations		[]*Invocation
-	counter uint
-	mutex           sync.Mutex
+	invocations []*Invocation
+	counter     uint
+	mutex       sync.Mutex
 }
 
 func newInvokerMock() *invokerMock {
-	return &invokerMock{counter:0}
+	return &invokerMock{counter: 0}
 }
 
 func (m *invokerMock) Invoke(topic string, message *[]byte) {
@@ -116,13 +116,11 @@ func (m *invokerMock) GetInvocations() []*Invocation {
 	defer m.mutex.Unlock()
 	return m.invocations
 }
+
 //---- Invoker Mock ----//
 
-
-
-func TestMain(m *testing.M){
-	os.Setenv("RMQ_TOPICS", "unit_test")
-	os.Setenv("RMQ_QUEUE", "Queue")
+func TestMain(m *testing.M) {
+	os.Setenv("RMQ_TOPICS", "unit_test,another_topic")
 	os.Setenv("RMQ_EXCHANGE", "Ex")
 	os.Setenv("RMQ_HOST", "localhost")
 	os.Setenv("RMQ_PORT", "5672")
@@ -130,7 +128,6 @@ func TestMain(m *testing.M){
 	os.Setenv("RMQ_PASS", "pass")
 
 	defer os.Unsetenv("RMQ_TOPICS")
-	defer os.Unsetenv("RMQ_QUEUE")
 	defer os.Unsetenv("RMQ_EXCHANGE")
 	defer os.Unsetenv("RMQ_HOST")
 	defer os.Unsetenv("RMQ_PORT")
@@ -158,8 +155,7 @@ func TestMain(m *testing.M){
 	os.Exit(m.Run())
 }
 
-
-func TestSystem(t *testing.T)  {
+func TestSystem(t *testing.T) {
 	connector.Start()
 	time.Sleep(10 * time.Second)
 
@@ -168,7 +164,7 @@ func TestSystem(t *testing.T)  {
 			message := []byte(fmt.Sprintf("I'm Message %d", i))
 			err := producerClient.SendMessage(&message)
 
-			if err != nil{
+			if err != nil {
 				log.Printf("Received error %s for message %d", err, i)
 				i--
 			}
@@ -183,6 +179,7 @@ func TestSystem(t *testing.T)  {
 
 		mockClient.invocations = nil
 	})
+
 	connector.End()
 	time.Sleep(10 * time.Second)
 
@@ -191,7 +188,7 @@ func TestSystem(t *testing.T)  {
 			message := []byte(fmt.Sprintf("I'm Message %d send while beeing inactive", i))
 			err := producerClient.SendMessage(&message)
 
-			if err != nil{
+			if err != nil {
 				log.Printf("Received error %s for message %d", err, i)
 				i--
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,6 @@ type Controller struct {
 	RabbitSanitizedURL  string
 
 	ExchangeName string
-	QueueName    string
 	Topics       []string
 
 	TopicRefreshTime time.Duration
@@ -40,7 +39,6 @@ func NewConfig() (*Controller, error) {
 		return nil, err
 	}
 
-	queue := readFromEnv(envRabbitQueue, "OpenFaaSQueue")
 	exchange := readFromEnv(envRabbitExchange, "OpenFaasEx")
 
 	topics, err := getTopics()
@@ -54,7 +52,6 @@ func NewConfig() (*Controller, error) {
 		RabbitSanitizedURL:  sanitizedURL,
 
 		ExchangeName: exchange,
-		QueueName:    queue,
 		Topics:       topics,
 
 		TopicRefreshTime: getRefreshTime(),
@@ -69,7 +66,6 @@ const envRabbitPort = "RMQ_PORT"
 
 const envRabbitTopics = "RMQ_TOPICS"
 const envRabbitExchange = "RMQ_EXCHANGE"
-const envRabbitQueue = "RMQ_QUEUE"
 
 const envRefreshTime = "TOPIC_MAP_REFRESH_TIME"
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -51,6 +52,27 @@ func TestNewConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("With invalid RefreshTime", func(t *testing.T) {
+		os.Setenv("TOPIC_MAP_REFRESH_TIME", "is_string")
+		defer os.Unsetenv("TOPIC_MAP_REFRESH_TIME")
+
+		var duration time.Duration
+
+		duration = getRefreshTime()
+
+		if duration.Seconds() != 30 {
+			t.Errorf("Should fallback to 30s instead it was %f", duration.Seconds())
+		}
+
+		os.Setenv("TOPIC_MAP_REFRESH_TIME", "66,31h")
+
+		duration = getRefreshTime()
+
+		if duration.Seconds() != 30 {
+			t.Errorf("Should fallback to 30s instead it was %f", duration.Seconds())
+		}
+	})
+
 	t.Run("Empty Topics", func(t *testing.T) {
 		os.Setenv("RMQ_TOPICS", "")
 		defer os.Unsetenv("RMQ_TOPICS")
@@ -84,10 +106,6 @@ func TestNewConfig(t *testing.T) {
 
 		if config.ExchangeName != "OpenFaasEx" {
 			t.Errorf("Expected OpenFaasEx Received %s", config.ExchangeName)
-		}
-
-		if config.QueueName != "OpenFaaSQueue" {
-			t.Errorf("Expected OpenFaaSQueue Received %s", config.QueueName)
 		}
 
 		if len(config.Topics) != 1 {
@@ -139,10 +157,6 @@ func TestNewConfig(t *testing.T) {
 
 		if config.ExchangeName != "Ex" {
 			t.Errorf("Expected Ex Received %s", config.ExchangeName)
-		}
-
-		if config.QueueName != "Queue" {
-			t.Errorf("Expected Queue Received %s", config.QueueName)
 		}
 
 		if config.TopicRefreshTime.Seconds() != 40 {

--- a/pkg/rabbitmq/queue_consumer.go
+++ b/pkg/rabbitmq/queue_consumer.go
@@ -23,8 +23,8 @@ type QueueConsumer interface {
 }
 
 // NewQueueConsumer creates a new instance of QueueConsumer and assigns the passed channel to it.
-func NewQueueConsumer(channel *amqp.Channel) QueueConsumer {
-	return &queueConsumer{channel: channel}
+func NewQueueConsumer(queueName string, channel *amqp.Channel) QueueConsumer {
+	return &queueConsumer{queueName: queueName, channel: channel}
 }
 
 func (c *queueConsumer) Consume() (<-chan *types.OpenFaaSInvocation, error) {

--- a/pkg/subscriber/subscriber.go
+++ b/pkg/subscriber/subscriber.go
@@ -52,7 +52,7 @@ func (s *subscriber) Start() error {
 
 		for received := range errors {
 			if received.Recover {
-				log.Printf("Received non cirtical error %s. Will try to recover worker %s", received, s.name)
+				log.Printf("Received non critical error %s. Will try to recover worker %s", received, s.name)
 				_ = s.Stop()
 				_ = s.Start()
 			} else {
@@ -67,8 +67,6 @@ func (s *subscriber) Start() error {
 			if s.topic == invocation.Topic {
 				go func() {
 					s.client.Invoke(s.topic, invocation.Message)
-					// TEMP
-					log.Printf("Message %s", *invocation.Message)
 					log.Printf("Finished invocations of functions on topic %s", s.topic)
 				}()
 			} else {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	//DEVVersion string for the development version
 	DEVVersion = "dev"
 	// DEVCommit string for the development version
-	DEVCommit  = "local"
+	DEVCommit = "local"
 )
 
 // GetReleaseInfo returns commit hash and version tag (if available).


### PR DESCRIPTION
This PR fixes #26. The root cause for the described issue was the fact that I limited the Queues to a single one. Now the Connector will create a dedicated Queue per Topic Key.

The Exchange is configured as `Direct`, which means it will forward incoming messages based on the Routing Key to Queues that bound to the specified key. This lead to a situation where the specified Queue would bind to multiple routing keys, which resulted in consumer receiving messages for topics that they are not handling. 