### PR TITLE
:bug: Fix development environment setup script

### DIFF
--- a/hack/development_env_setup.sh
+++ b/hack/development_env_setup.sh
@@ -1,8 +1,8 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 # Check the availability of required tools
 
-if ![ -x "$(command -v docker)" ]; then
+if ! [ -x "$(command -v docker)" ]; then
     echo "Missing Docker, please install it"
     exit 1
 fi
@@ -10,7 +10,7 @@ fi
 # Spawn Rabbit MQ
 
 substr="dev_rabbitmq"
-if [[ $(docker ps --filter name=dev_rabbitmq) =~ $substr ]]; then
+if ! [[ $(docker ps --filter name=dev_rabbitmq) =~ $substr ]]; then
     docker run -p 5672:5672 -e RABBITMQ_DEFAULT_USER="user" -e RABBITMQ_DEFAULT_PASS="pass" -d --restart always --name dev_rabbitmq rabbitmq:3.7.4
     echo "Started Rabbit MQ with the following config:"
     echo "Credentials: [Username: user Password: pass]"


### PR DESCRIPTION
When I ran the development environment setup, `./hack/development_env_setup.sh`, I got the following error message:

```
./hack/development_env_setup.sh: 5: ./hack/development_env_setup.sh: ![: not found
./hack/development_env_setup.sh: 13: ./hack/development_env_setup.sh: [[: not found
Rabbit MQ is already running
```

- The error at line 5 and 13 is because I'm running zsh instead of bash, so I changed to force to run in bash.
- The message "Rabbit MQ is already running" was in the output because the script was not trying to create the rabbitmq container, so I just added the `!` to create the container only if the container doesn't exist or it's not running.