### PR TITLE
:sparkles: Added INSECURE_SKIP_VERIFY parameter to skip certificate validation

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptSettings">
-    <option name="languageLevel" value="ES6" />
-  </component>
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/rabbitmq-connector.iml" filepath="$PROJECT_DIR$/.idea/rabbitmq-connector.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/rabbitmq-connector.iml
+++ b/.idea/rabbitmq-connector.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "env": {},
+            "args": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Queue. Information on the Topology of the Queue can be found [here](#Topology)
 
 * `REQ_TIMEOUT`: Request Timeout for invocations of OpenFaaS functions defaults to `30s`
 * `TOPIC_MAP_REFRESH_TIME`: Refresh time for the topic map defaults to `60s`
+* `INSECURE_SKIP_VERIFY`: Allows to skip verification of HTTP Cert for Communication Connector <=> OpenFaaS default is `false`. It is recommended to keep false, as enabling it opens up the possibility of a man in the middle attack.
 
 ### Topology
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Templum/rabbitmq-connector/pkg/config"
 	"github.com/Templum/rabbitmq-connector/pkg/rabbitmq"
 	"github.com/Templum/rabbitmq-connector/pkg/subscriber"
+	t "github.com/Templum/rabbitmq-connector/pkg/types"
 	"github.com/Templum/rabbitmq-connector/pkg/version"
 	"github.com/openfaas-incubator/connector-sdk/types"
 	"github.com/openfaas/faas-provider/auth"
@@ -44,6 +45,9 @@ func main() {
 
 	// Start SDK
 	controller := types.NewController(creds, controllerCfg)
+	// TODO: Remove work around (either by pushing it to the connector) or maybe by upgrading connector sdk
+	controller.Invoker.Client = t.MakeHTTPClient(connectorCfg.InsecureSkipVerify, controllerCfg.UpstreamTimeout)
+
 	controller.BeginMapBuilder()
 	log.Printf("Started Map Building. Be Aware it will take %s until the first map is avaliable.", connectorCfg.TopicRefreshTime)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,8 @@ type Controller struct {
 	ExchangeName string
 	Topics       []string
 
-	TopicRefreshTime time.Duration
+	TopicRefreshTime   time.Duration
+	InsecureSkipVerify bool
 }
 
 // NewConfig reads the connector config from environment variables and further validates them,
@@ -46,13 +47,19 @@ func NewConfig() (*Controller, error) {
 		return nil, err
 	}
 
+	skipVerify, err := strconv.ParseBool(readFromEnv(envSkipVerify, "false"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &Controller{
 		GatewayURL:          gatewayURL,
 		RabbitConnectionURL: rabbitURL,
 		RabbitSanitizedURL:  sanitizedURL,
 
-		ExchangeName: exchange,
-		Topics:       topics,
+		ExchangeName:       exchange,
+		Topics:             topics,
+		InsecureSkipVerify: skipVerify,
 
 		TopicRefreshTime: getRefreshTime(),
 	}, nil
@@ -68,6 +75,7 @@ const envRabbitTopics = "RMQ_TOPICS"
 const envRabbitExchange = "RMQ_EXCHANGE"
 
 const envRefreshTime = "TOPIC_MAP_REFRESH_TIME"
+const envSkipVerify = "INSECURE_SKIP_VERIFY"
 
 func getOpenFaaSUrl() (string, error) {
 	url := readFromEnv(envFaaSGwURL, "http://gateway:8080")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,6 +115,10 @@ func TestNewConfig(t *testing.T) {
 		if config.TopicRefreshTime.Seconds() != 30 {
 			t.Errorf("Expected 30s Received %fs", config.TopicRefreshTime.Seconds())
 		}
+
+		if config.InsecureSkipVerify != false {
+			t.Errorf("Expected false Received %t", config.InsecureSkipVerify)
+		}
 	})
 
 	t.Run("Override Config", func(t *testing.T) {
@@ -127,6 +131,7 @@ func TestNewConfig(t *testing.T) {
 		os.Setenv("RMQ_PASS", "password")
 		os.Setenv("OPEN_FAAS_GW_URL", "https://gateway")
 		os.Setenv("TOPIC_MAP_REFRESH_TIME", "40s")
+		os.Setenv("INSECURE_SKIP_VERIFY", "true")
 
 		defer os.Unsetenv("RMQ_TOPICS")
 		defer os.Unsetenv("RMQ_QUEUE")
@@ -137,6 +142,7 @@ func TestNewConfig(t *testing.T) {
 		defer os.Unsetenv("RMQ_PASS")
 		defer os.Unsetenv("OPEN_FAAS_GW_URL")
 		defer os.Unsetenv("TOPIC_MAP_REFRESH_TIME")
+		defer os.Unsetenv("INSECURE_SKIP_VERIFY")
 
 		config, err := NewConfig()
 		if err != nil {
@@ -161,6 +167,10 @@ func TestNewConfig(t *testing.T) {
 
 		if config.TopicRefreshTime.Seconds() != 40 {
 			t.Errorf("Expected 40s Received %fs", config.TopicRefreshTime.Seconds())
+		}
+
+		if config.InsecureSkipVerify != true {
+			t.Errorf("Expected true Received %t", config.InsecureSkipVerify)
 		}
 	})
 }

--- a/pkg/types/httpClientFactory.go
+++ b/pkg/types/httpClientFactory.go
@@ -1,0 +1,28 @@
+package types
+
+// Copyright (c) Simon Pelczer 2019. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// MakeHTTPClient generates an HTTP Client setting basic properties including timeouts
+func MakeHTTPClient(insecure bool, timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   timeout,
+				KeepAlive: 10 * time.Second,
+			}).DialContext,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			IdleConnTimeout:     120 * time.Millisecond,
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: insecure},
+		},
+	}
+}


### PR DESCRIPTION
This PR implements the feature request #37 by introducing a new environment variable named `INSECURE_SKIP_VERIFY`, which controls the verification of the certificate chain for the HTTP Client, that is used to communicate with OpenFaaS.