### PR TITLE
Create initial helm chart

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rabbitmq-connector
+description: A Helm chart for the rabbitmq connector to openfaas
+type: application
+version: 0.0.0
+appVersion: 0.1.4

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: basic_auth
+            value: "true"
+          - name: secret_mount_path
+            value: {{ .Values.openfaas.secretMountPath }}
+          - name: OPEN_FAAS_GW_URL
+            value: http://{{ .Values.openfaas.host }}:{{ .Values.openfaas.port }}
+          - name: RMQ_TOPICS
+            value: {{ .Values.rmq.topics }}
+          - name: RMQ_HOST
+            value: {{ .Values.rmq.host }}
+          - name: RMQ_PORT
+            value: {{ .Values.rmq.port | quote }}
+          - name: RMQ_USER
+            value: {{ .Values.rmq.user }}
+          {{- if .Values.rmq.existingPasswordSecret }}
+          - name: RMQ_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.rmq.existingPasswordSecret }}
+                key: rabbitmq-password
+          {{- else }}
+          - name: RMQ_PASS
+            value: {{ .Values.rmq.password }}
+          {{- end }}
+          - name: REQ_TIMEOUT
+            value: {{ .Values.service.requestTimeout | quote }}
+          - name: TOPIC_MAP_REFRESH_TIME
+            value: {{ .Values.service.topiceMapRefreshTime | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: openfaas-basic-auth
+            readOnly: true
+            mountPath: {{ .Values.openfaas.secretMountPath }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: openfaas-basic-auth
+        secret:
+          secretName: {{ include "chart.fullname" . }}-basic-auth

--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chart.fullname" . }}-basic-auth
+  labels: {{- include "chart.labels" . | nindent 4 }}
+type: Opaque
+data:
+  basic-auth-password: {{ .Values.openfaas.password | b64enc | quote }}
+  basic-auth-user: {{ .Values.openfaas.username | b64enc | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,85 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# rabbitmq-connector was never tested with more than 1 instance
+replicaCount: 1
+
+image:
+  repository: templum/rabbitmq-connector
+  tag: v0.1.4
+
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  pullSecrets: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+openfaas:
+  # in a default installation, it would be gateway.openfaas
+  host: ""
+  port: 8080
+  secretMountPath: /etc/openfaas
+  # openfaas login data
+  username: ""
+  password: ""
+
+rmq:
+  # comma-separated list of topics, eg. billing,account,support
+  topics: ""
+  # rabbitmq hostname
+  host: ""
+  port: 5672
+  # rabbitmq credentials
+  user: ""
+  # either you give the password or the existing password secret
+  password: ""
+  # if it exists, the password secret needs to have a key "rabbitmq-password" 
+  # (same requirement as for rabbitmq helm chart)
+  existingPasswordSecret: ""
+
+service:
+  requestTimeout: 30s
+  topiceMapRefreshTime: 30s
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,7 +38,7 @@ rmq:
   user: ""
   # either you give the password or the existing password secret
   password: ""
-  # if it exists, the password secret needs to have a key "rabbitmq-password" 
+  # if it exists, the password secret needs to have a key "rabbitmq-password"
   # (same requirement as for rabbitmq helm chart)
   existingPasswordSecret: ""
 


### PR DESCRIPTION
As proposed in issue #60, I share my helm chart for the rabbitmq-connector. It suits my personal needs, I can imagine that we would like to improve it within this PR or later on. It features the bare minimum that is necessary to make the connector work. What might be missing here is a `NOTES.txt` which would give some details on the deployed helm chart to the user.