### PR TITLE
:sparkles: Ack & Nack based on Function outcome

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "basic_auth": "false",
                 "OPEN_FAAS_GW_URL": "http://localhost:8080",
                 "RMQ_USER": "user",
-                "RMQ_PASS": "SDsozNEnN1",
+                "RMQ_PASS": "pass",
                 "RMQ_HOST": "localhost",
                 "PATH_TO_TOPOLOGY":"${workspaceFolder}/artifacts/example_topology.yaml"
             },

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Using the [OpenFaaS CLI](https://github.com/openfaas/faas-cli) or [Rest API](htt
 deploy a function which has an `annotation` named `topic`, this has to be a comma-separated string of the relevant topics.
 E.g. `log,monitoring,billing`.
 
+In case an error occurred during the invocation of the function(s) the message is attempted to be transferred back to the Queue. Therefore you should ensure your functions can handle being called potentially twice with the same payload.
+
+Further the returned output from the function is ignored, as the connector currently only supports fire & forget flows.
+
 Please also make sure to check out the official Rabbit MQ documentation [here](https://www.rabbitmq.com/production-checklist.html) and [here](https://www.rabbitmq.com/monitoring.html) in order to avoid message dropping.
 
 ### Configuration

--- a/pkg/openfaas/function_map_builder.go
+++ b/pkg/openfaas/function_map_builder.go
@@ -42,7 +42,7 @@ func (b *FunctionMapBuilder) Append(topic string, function string) {
 	b.target[key] = append(b.target[key], function)
 }
 
-// Build returns a map containing values based on privous Append calls
+// Build returns a map containing values based on previous Append calls
 func (b *FunctionMapBuilder) Build() map[string][]string {
 	return b.target
 }

--- a/pkg/rabbitmq/exchange_test.go
+++ b/pkg/rabbitmq/exchange_test.go
@@ -16,13 +16,32 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+type acknowledgerMock struct {
+	mock.Mock
+}
+
+func (a *acknowledgerMock) Ack(tag uint64, multiple bool) error {
+	args := a.Called(tag, multiple)
+	return args.Error(0)
+}
+
+func (a *acknowledgerMock) Nack(tag uint64, multiple bool, requeue bool) error {
+	args := a.Called(tag, multiple, requeue)
+	return args.Error(0)
+}
+
+func (a *acknowledgerMock) Reject(tag uint64, requeue bool) error {
+	args := a.Called(tag, requeue)
+	return args.Error(0)
+}
+
 type invokerMock struct {
 	mock.Mock
 }
 
 func (i *invokerMock) Invoke(topic string, invocation *types.OpenFaaSInvocation) error {
-	i.Called(topic, invocation)
-	return nil
+	args := i.Called(topic, invocation)
+	return args.Error(0)
 }
 
 func TestExchange_Start(t *testing.T) {
@@ -33,8 +52,8 @@ func TestExchange_Start(t *testing.T) {
 
 	t.Run("Should successfully start consuming for defined topics", func(t *testing.T) {
 		channel := new(channelMock)
-		channel.On("Consume", "OpenFaaS_Nasdaq_Billing", "", true, false, false, false, amqp.Table{}).Return(make(<-chan amqp.Delivery), nil)
-		channel.On("Consume", "OpenFaaS_Nasdaq_Transport", "", true, false, false, false, amqp.Table{}).Return(make(<-chan amqp.Delivery), nil)
+		channel.On("Consume", "OpenFaaS_Nasdaq_Billing", "", false, false, false, false, amqp.Table{}).Return(make(<-chan amqp.Delivery), nil)
+		channel.On("Consume", "OpenFaaS_Nasdaq_Transport", "", false, false, false, false, amqp.Table{}).Return(make(<-chan amqp.Delivery), nil)
 		channel.On("NotifyClose", mock.Anything).Return(make(chan *amqp.Error))
 
 		invoker := new(invokerMock)
@@ -50,7 +69,7 @@ func TestExchange_Start(t *testing.T) {
 
 	t.Run("Should return occurred error when starting consume failed", func(t *testing.T) {
 		channel := new(channelMock)
-		channel.On("Consume", "OpenFaaS_Nasdaq_Billing", "", true, false, false, false, amqp.Table{}).Return(make(<-chan amqp.Delivery), errors.New("expected"))
+		channel.On("Consume", "OpenFaaS_Nasdaq_Billing", "", false, false, false, false, amqp.Table{}).Return(make(<-chan amqp.Delivery), errors.New("expected"))
 		channel.On("NotifyClose", mock.Anything).Return(make(chan *amqp.Error))
 
 		invoker := new(invokerMock)
@@ -83,9 +102,12 @@ func TestExchange_StartConsuming(t *testing.T) {
 		Topics: []string{"Billing"},
 	}
 
-	t.Run("Should invoke function when message with matching routingkey was received", func(t *testing.T) {
+	t.Run("Should invoke function when message is for registered routing key and further ack processing of message if no error occurred", func(t *testing.T) {
 		invoker := new(invokerMock)
-		invoker.On("Invoke", "Billing", mock.Anything)
+		invoker.On("Invoke", "Billing", mock.Anything).Return(nil)
+
+		acker := new(acknowledgerMock)
+		acker.On("Ack", mock.Anything, false).Return(nil)
 
 		target := Exchange{
 			client:     invoker,
@@ -93,6 +115,7 @@ func TestExchange_StartConsuming(t *testing.T) {
 		}
 
 		target.StartConsuming("Billing", createDeliveries(amqp.Delivery{
+			Acknowledger:    acker,
 			ContentType:     "text/plain",
 			ContentEncoding: "utf-8",
 			RoutingKey:      "Billing",
@@ -100,11 +123,91 @@ func TestExchange_StartConsuming(t *testing.T) {
 		}))
 
 		invoker.AssertExpectations(t)
+		acker.AssertExpectations(t)
 	})
 
-	t.Run("Should not invoke when received message is of no registered topic", func(t *testing.T) {
+	t.Run("Should attempt to ack successful invocations up to 3 times", func(t *testing.T) {
 		invoker := new(invokerMock)
-		invoker.On("Invoke", "Billing", mock.Anything)
+		invoker.On("Invoke", "Billing", mock.Anything).Return(nil)
+
+		acker := new(acknowledgerMock)
+		acker.On("Ack", mock.Anything, false).Return(errors.New("failed"))
+
+		target := Exchange{
+			client:     invoker,
+			definition: &definition,
+		}
+
+		target.StartConsuming("Billing", createDeliveries(amqp.Delivery{
+			Acknowledger:    acker,
+			ContentType:     "text/plain",
+			ContentEncoding: "utf-8",
+			RoutingKey:      "Billing",
+			Body:            []byte("Hello World"),
+		}))
+
+		time.Sleep(2 * time.Second)
+
+		acker.AssertExpectations(t)
+		acker.AssertNumberOfCalls(t, "Ack", 3)
+	})
+
+	t.Run("Should invoke function when message is for registered routing key and further send back to queue when error occurred", func(t *testing.T) {
+		invoker := new(invokerMock)
+		invoker.On("Invoke", "Billing", mock.Anything).Return(errors.New("failed to invoke"))
+
+		acker := new(acknowledgerMock)
+		acker.On("Nack", mock.Anything, false, true).Return(nil)
+
+		target := Exchange{
+			client:     invoker,
+			definition: &definition,
+		}
+
+		target.StartConsuming("Billing", createDeliveries(amqp.Delivery{
+			Acknowledger:    acker,
+			ContentType:     "text/plain",
+			ContentEncoding: "utf-8",
+			RoutingKey:      "Billing",
+			Body:            []byte("Hello World"),
+		}))
+
+		invoker.AssertExpectations(t)
+		acker.AssertExpectations(t)
+	})
+
+	t.Run("Should attempt to nack unsuccessful invocations up to 3 times", func(t *testing.T) {
+		invoker := new(invokerMock)
+		invoker.On("Invoke", "Billing", mock.Anything).Return(errors.New("failed to invoke"))
+
+		acker := new(acknowledgerMock)
+		acker.On("Nack", mock.Anything, false, true).Return(errors.New("failed"))
+
+		target := Exchange{
+			client:     invoker,
+			definition: &definition,
+		}
+
+		target.StartConsuming("Billing", createDeliveries(amqp.Delivery{
+			Acknowledger:    acker,
+			ContentType:     "text/plain",
+			ContentEncoding: "utf-8",
+			RoutingKey:      "Billing",
+			Body:            []byte("Hello World"),
+		}))
+
+		time.Sleep(2 * time.Second)
+
+		acker.AssertExpectations(t)
+		acker.AssertNumberOfCalls(t, "Nack", 3)
+	})
+
+	t.Run("Should not invoke when received message is of no registered topic and further reject message and send it back to queue", func(t *testing.T) {
+		invoker := new(invokerMock)
+		invoker.On("Invoke", "Billing", mock.Anything).Return(nil)
+
+		acker := new(acknowledgerMock)
+		acker.On("Reject", mock.Anything, true).Return(nil)
 
 		target := Exchange{
 			client:     invoker,
@@ -112,6 +215,7 @@ func TestExchange_StartConsuming(t *testing.T) {
 		}
 
 		target.StartConsuming("Account", createDeliveries(amqp.Delivery{
+			Acknowledger:    acker,
 			ContentType:     "text/plain",
 			ContentEncoding: "utf-8",
 			RoutingKey:      "Billing",
@@ -119,6 +223,31 @@ func TestExchange_StartConsuming(t *testing.T) {
 		}))
 
 		invoker.AssertNotCalled(t, "Invoke", mock.Anything)
+		acker.AssertExpectations(t)
+	})
+
+	t.Run("Should attempt to reject deliveries for unregistered topics up to 3 times", func(t *testing.T) {
+		invoker := new(invokerMock)
+		invoker.On("Invoke", "Billing", mock.Anything).Return(nil)
+
+		acker := new(acknowledgerMock)
+		acker.On("Reject", mock.Anything, true).Return(errors.New("failed"))
+
+		target := Exchange{
+			client:     invoker,
+			definition: &definition,
+		}
+
+		target.StartConsuming("Account", createDeliveries(amqp.Delivery{
+			Acknowledger:    acker,
+			ContentType:     "text/plain",
+			ContentEncoding: "utf-8",
+			RoutingKey:      "Billing",
+			Body:            []byte("Hello World"),
+		}))
+
+		acker.AssertExpectations(t)
+		acker.AssertNumberOfCalls(t, "Reject", 3)
 	})
 }
 

--- a/pkg/rabbitmq/exchange_test.go
+++ b/pkg/rabbitmq/exchange_test.go
@@ -20,8 +20,9 @@ type invokerMock struct {
 	mock.Mock
 }
 
-func (i *invokerMock) Invoke(topic string, invocation *types.OpenFaaSInvocation) {
+func (i *invokerMock) Invoke(topic string, invocation *types.OpenFaaSInvocation) error {
 	i.Called(topic, invocation)
+	return nil
 }
 
 func TestExchange_Start(t *testing.T) {

--- a/pkg/types/invoker.go
+++ b/pkg/types/invoker.go
@@ -8,5 +8,5 @@ package types
 // Invoker is the Interface used by the OpenFaaS Connector SDK to perform invocations
 // of Lambdas based on a provided topic and message
 type Invoker interface {
-	Invoke(topic string, invocation *OpenFaaSInvocation)
+	Invoke(topic string, invocation *OpenFaaSInvocation) error
 }


### PR DESCRIPTION
This PR closes #89. Based on the outcome of the function the delivery is either acked or nacked and returned to the Queue. Further questions that are received by the connector, but don't have the right routing key will be rejected and requeued as well.