### PR TITLE
:wrench: Performed Migration to V3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2.5.0
+        uses: docker/metadata-action@v3
         with:
           images: templum/rabbitmq-connector, ghcr.io/templum/rabbitmq-connector
           label-custom: |


### PR DESCRIPTION
This closes #128 by performing the correct migration to version 3.x.x. 

Based on the steps defined [here](https://github.com/docker/metadata-action/blob/master/UPGRADE.md)