### PR TITLE
:bug: :boom: No longer ignoring Credentials when present and TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ RabbitMQ Related:
 * `RMQ_HOST`: Hostname/ip of Rabbit MQ
 * `RMQ_PORT`: Port of Rabbit MQ
 * `RMQ_VHOST`: Used to specify the vhost for Rabbit MQ, will default to `/`
-* `RMQ_USER`: Defaults to `guest`
-* `RMQ_PASS`: Defaults to `pass`
+* `RMQ_USER`: Defaults to "", if user and pass are both "" than no credentials will be used for connecting
+* `RMQ_PASS`: Defaults to "", if user and pass are both "" than no credentials will be used for connecting
 * `PATH_TO_TOPOLOGY`: Path to the yaml describing the topology, has _no_ default and is *required*
 
 ### Topology Configuration

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -244,7 +244,7 @@ data:
 		assert.Nil(t, err, "Should not throw")
 		assert.Nil(t, config.TLSConfig, "Should not have a TLS config")
 		assert.Equal(t, config.GatewayURL, "http://gateway:8080", "Expected default value")
-		assert.Equal(t, config.RabbitConnectionURL, "amqp://user:pass@localhost:5672/", "Expected default value")
+		assert.Equal(t, config.RabbitConnectionURL, "amqp://localhost:5672/", "Expected default value")
 		assert.NotContains(t, config.RabbitSanitizedURL, "user:pass", "Expected credentials not to be present")
 		assert.Equal(t, config.RabbitSanitizedURL, "amqp://localhost:5672/", "Expected default value")
 		assert.Equal(t, config.TopicRefreshTime, 30*time.Second, "Expected default value")


### PR DESCRIPTION
This change introduces a breaking change by no longer defaulting credentials to user + pass when the env is empty or not present.

Further now it will leverage credentials if present also for TLS connection. Minor refactoring occurred as well.

This fixes #190