### PR TITLE
:bug: Fixing incorrect use of HTTP Methods in communication with OF

### DIFF
--- a/pkg/openfaas/client.go
+++ b/pkg/openfaas/client.go
@@ -77,6 +77,7 @@ func (c *Client) InvokeSync(ctx context.Context, name string, invocation *intern
 		req.SetBody(nil)
 	}
 
+	req.Header.SetMethod(fasthttp.MethodPost)
 	req.Header.Set("Content-Type", invocation.ContentType)
 	req.Header.Set("Content-Encoding", invocation.ContentEncoding)
 	req.Header.SetUserAgent("OpenFaaS - Rabbit MQ Connector")
@@ -118,6 +119,7 @@ func (c *Client) InvokeAsync(ctx context.Context, name string, invocation *inter
 		req.SetBody(nil)
 	}
 
+	req.Header.SetMethod(fasthttp.MethodPost)
 	req.Header.Set("Content-Type", invocation.ContentType)
 	req.Header.Set("Content-Encoding", invocation.ContentEncoding)
 	req.Header.SetUserAgent("OpenFaaS - Rabbit MQ Connector")
@@ -154,6 +156,7 @@ func (c *Client) HasNamespaceSupport(ctx context.Context) (bool, error) {
 
 	req.SetRequestURI(getNamespaces)
 
+	req.Header.SetMethod(fasthttp.MethodGet)
 	req.Header.SetUserAgent("OpenFaaS - Rabbit MQ Connector")
 	if c.credentials != nil {
 		credentials := c.credentials.User + ":" + c.credentials.Password
@@ -190,6 +193,7 @@ func (c *Client) GetNamespaces(ctx context.Context) ([]string, error) {
 
 	req.SetRequestURI(getNamespaces)
 
+	req.Header.SetMethod(fasthttp.MethodGet)
 	req.Header.SetUserAgent("OpenFaaS - Rabbit MQ Connector")
 	if c.credentials != nil {
 		credentials := c.credentials.User + ":" + c.credentials.Password
@@ -226,6 +230,7 @@ func (c *Client) GetFunctions(ctx context.Context, namespace string) ([]types.Fu
 
 	req.SetRequestURI(getFunctions)
 
+	req.Header.SetMethod(fasthttp.MethodGet)
 	req.Header.SetUserAgent("OpenFaaS - Rabbit MQ Connector")
 	if c.credentials != nil {
 		credentials := c.credentials.User + ":" + c.credentials.Password

--- a/pkg/openfaas/client_test.go
+++ b/pkg/openfaas/client_test.go
@@ -43,6 +43,12 @@ func TestClient_InvokeSync(t *testing.T) {
 			return
 		}
 
+		if r.Method != fasthttp.MethodPost {
+			w.WriteHeader(400)
+			fmt.Fprint(w, "Method not supported")
+			return
+		}
+
 		switch r.URL.Path {
 		case "/function/exists":
 			w.WriteHeader(200)
@@ -127,6 +133,12 @@ func TestClient_InvokeAsync(t *testing.T) {
 			return
 		}
 
+		if r.Method != fasthttp.MethodPost {
+			w.WriteHeader(400)
+			fmt.Fprint(w, "Method not supported")
+			return
+		}
+
 		switch r.URL.Path {
 		case "/async-function/exists":
 			w.WriteHeader(202)
@@ -207,6 +219,12 @@ func TestClient_HasNamespaceSupport(t *testing.T) {
 			}
 			w.WriteHeader(401)
 			fmt.Fprint(w, "unauthorized")
+			return
+		}
+
+		if r.Method != fasthttp.MethodGet {
+			w.WriteHeader(400)
+			fmt.Fprint(w, "Method not supported")
 			return
 		}
 
@@ -324,6 +342,12 @@ func TestClient_GetFunctions(t *testing.T) {
 			return
 		}
 
+		if r.Method != fasthttp.MethodGet {
+			w.WriteHeader(400)
+			fmt.Fprint(w, "Method not supported")
+			return
+		}
+
 		namespace := r.URL.Query().Get("namespace")
 		if len(namespace) > 0 {
 			if namespace == "special" {
@@ -407,6 +431,12 @@ func TestClient_GetNamespaces(t *testing.T) {
 			}
 			w.WriteHeader(401)
 			fmt.Fprint(w, "unauthorized")
+			return
+		}
+
+		if r.Method != fasthttp.MethodGet {
+			w.WriteHeader(400)
+			fmt.Fprint(w, "Method not supported")
 			return
 		}
 


### PR DESCRIPTION
This PR fixes #193 by implementing proper HTTP Method usage and further extending of existing Testsuite to correctly catch this.

Seems like not all versions of OF are strictly expecting a POST, hence this bug slipped until now