### PR TITLE
:arrow_up: Upgrade golang 1.19 => 1.20

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.6/containers/go/.devcontainer/base.Dockerfile
 
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT="1.19-bullseye"
+ARG VARIANT="1.20-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "1.19-bullseye",
+			"VARIANT": "1.20-bullseye",
 			// Options
 			"NODE_VERSION": "none"
 		}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: 1.20.0
           cache: false
 
       - name: Build
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: 1.20.0
           cache: false
 
       - name: K8S Cluster Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-          cache: true
+          go-version: 1.20
+          cache: false
 
       - name: Build
         run: go build -v ./...
@@ -103,8 +103,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-          cache: true
+          go-version: 1.20
+          cache: false
 
       - name: K8S Cluster Setup
         uses: helm/kind-action@v1.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.5-alpine as base_builder
+FROM golang:1.20.0-alpine as base_builder
 
 RUN apk --no-cache add ca-certificates git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Templum/rabbitmq-connector
 
-go 1.19
+go 1.20
 
 require (
 	github.com/docker/go-connections v0.4.0


### PR DESCRIPTION
This properly implements the upgrade of go from 1.19 to 1.20. This closes #308 by upgrading the docker file, along with Github & Devcontainer setup. 